### PR TITLE
Update link to usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Using the provider
 ------------------
 If you're building the provider, follow the instructions to [install it as a plugin.](https://www.terraform.io/docs/plugins/basics.html#installing-a-plugin) After placing it into your plugins directory,  run `terraform init` to initialize it.
 
-Further [usage documentation is available on the Terraform website](https://www.terraform.io/docs/providers/zabbix/index.html).
+Further [usage documentation is available on the Terraform website](https://registry.terraform.io/providers/claranet/zabbix/latest/docs).
 
 Developing the Provider
 -----------------------


### PR DESCRIPTION
The old link was 404'ing.