### PR TITLE
intoduce tls_insecure in provider config for skipping tls cert verification

### DIFF
--- a/website/docs/index.html.markdown
+++ b/website/docs/index.html.markdown
@@ -42,3 +42,4 @@ The following arguments are supported:
 * `user` - (Required) Zabbix username. This can also be set via the `ZABBIX_USER` environment variable.
 * `password` - (Required) Zabbix user password. This can also be set via the `ZABBIX_PASSWORD` environment variable.
 * `server_url` - (Required) The API Url. This can be also be set via the `ZABBIX_SERVER_URL` environment variable. Note that this URL must point to `api_jsonrpc.php`. For example `http://localhost/api_jsonrpc.php`.
+* `tls_insecure` - (Optional) Set to `true` for skipping verification of TLS certificates. Also can be set via `ZABBIX_TLS_INSECURE`.


### PR DESCRIPTION
Hi,

This PR introduces `tls_insecure` as provider config field for disabling the verification of the TLS certificate that a zabbix instance exposed. I successfully tested it in my setup.

Any feedback appreciated :) 